### PR TITLE
Add Tekton in CI/CD list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Spinnaker - [Spinnaker is an open source, multi-cloud continuous delivery platfo
 werf - [GitOps tool to deliver apps to Kubernetes and integrate this process with GitLab and other CI tools](https://github.com/werf/werf)<br>
 Flux - [GitOps Kubernetes operator](https://github.com/fluxcd/flux)<br>
 Argo CD - [Declarative continuous deployment for Kubernetes](https://github.com/argoproj/argo-cd)<br>
-
+Tekton - [A cloud native continuous integration and delivery (CI/CD) solution](https://github.com/tektoncd/pipeline)<br>
 
 ## Kubernetes Security Tools
 klum - [Kubernetes Lazy User Manager](https://github.com/ibuildthecloud/klum)<br>


### PR DESCRIPTION
Tekton is a powerful and flexible open-source framework for creating CI/CD systems, allowing developers to build, test, and deploy across cloud providers and on-premise systems. More info: https://tekton.dev/