### PR TITLE
Adding OPA based conftest in testing tools catagory

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Litmus - [Cloud-Native Chaos Engineering; Kubernetes-Native Chaos Engineering; C
 PowerfulSeal - [A powerful testing tool for Kubernetes clusters](https://github.com/bloomberg/powerfulseal)<br>
 kube-burner - [Kube-burner is a tool aimed at stressing kubernetes clusters](https://kube-burner.readthedocs.io/en/latest/)<br>
 kube-monkey - [kube-monkey randomly deletes k8 pods in the cluster to validate failure-resilient services](https://github.com/asobti/kube-monkey/)<br>
+conftest - [Conftest helps you write tests against structured configuration data. Using Conftest you can write tests for your Kubernetes configurations and manifests.](https://github.com/open-policy-agent/conftest)<br>
 
 ## Service Mesh
 


### PR DESCRIPTION
Conftest helps you write tests against structured configuration data. Using Conftest you can write tests for your Kubernetes configurations and manifests