### PR TITLE
Fix Lens IDE entry

### DIFF
--- a/_data/development-tools-kit.yml
+++ b/_data/development-tools-kit.yml
@@ -26,7 +26,7 @@
   title: Java annotation processors for Kubernetes
   url: https://github.com/dekorateio/dekorate
 
-- topic: Lens IDE [The Kubernetes IDE
+- topic: Lens IDE
   url: https://k8slens.dev/
 
 - topic: Kosko


### PR DESCRIPTION
Something about the open bracket is breaking the link to the Lens website.