### PR TITLE
readme(update): Add Tracetest

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ PowerfulSeald - [A powerful testing tool for Kubernetes clusters](https://github
 
 kube-burnerd - [Kube-burner is a tool aimed at stressing kubernetes clusters](https://kube-burner.readthedocs.io/en/latest/)
 
+Tracetest - [Generate end-to-end and integration tests automatically from your OpenTelemetry traces](https://github.com/kubeshop/tracetest)
 
 ## Service Mesh
 
@@ -356,6 +357,8 @@ Kubevious - [Kubevious is an app-centric assurance, validation, and introspectio
 OpenTelemetry - [High-quality, ubiquitous, and portable telemetry to enable effective observability](https://opentelemetry.io/)
 
 Grafana Tempo - [Grafana Tempo is a high volume, minimal dependency distributed tracing backend](https://github.com/grafana/tempo)
+
+Tracetest - [Generate end-to-end and integration tests automatically from your OpenTelemetry traces](https://github.com/kubeshop/tracetest)
 
 ## Machine Learning/Deep Learning
 


### PR DESCRIPTION
This PR updates the `readme.md` to add a mention of Tracetest. A new open-source project for running end-to-end and integration tests against trace data generated from your OpenTelemetry traces.

Wwebsite: https://tracetest.io/
GitHub repo: https://github.com/kubeshop/tracetest