### PR TITLE
chore: Add Lab42/mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |       15      |       yupd            |       [       Yupd is a command-line tool that allows updating YAML files the GitOps way](https://github.com/srozange/yupd)   | ![GitHub Stars](https://img.shields.io/github/stars/srozange/yupd)   |
 |	16	|	kube-job  	|	[	Run one off job on kubernetes from the command line tool](https://github.com/h3poteto/kube-job)	|	![Github Stars](https://img.shields.io/github/stars/h3poteto/kube-job)	|
 |	17	|	paster  	|	[	This program base64 encodes a file, then pastes chunks it into an activated window using 'Ctrl+V' in the pod ](https://github.com/BuFuuu/paster/tree/main)	|	-	|
-
+|	18	|	Mirror  	|	[	A Kubernetes ConfigMap and Secrets reflector with a strong emphasis on security and performance	](https://github.com/lab42/mirror/tree/main)	|	![Github Stars](https://img.shields.io/github/stars/lab42/mirror)	|
 
 ## Maintainer
 


### PR DESCRIPTION
## Changes:

- Added [Mirror](https://github.com/lab42/mirror)

This project is a Kubernetes ConfigMap and Secrets reflector with a strong emphasis on security and performance.


## Reasoning for writing another reflector:

I created this reflector, because i needed something easy to use that is performant and without the attack vectors a larger image with various tools could provide.

