### PR TITLE
Added Claudie

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |	7	|	Porter  	|	[   Kubernetes-powered PaaS that runs in your own cloud.](https://github.com/porter-dev/porter)	|	![Github Stars](https://img.shields.io/github/stars/porter-dev/porter)	|
 |	8	|	Kubicorn  	|	[   Create, manage, snapshot, and scale Kubernetes infrastructure in the public cloud](https://github.com/kubicorn/kubicorn)	|	![Github Stars](https://img.shields.io/github/stars/kubicorn/kubicorn)	|
 |	9	|	eksdemo  	|	[ The easy button for learning, testing and demoing Amazon EKS  ](https://github.com/awslabs/eksdemo)	|	![Github Stars](https://img.shields.io/github/stars/awslabs/eksdemo)	|
+|	10	|	Claudie   	|	[ Claudie allows users to manage Kubernetes clusters that span across multiple cloud providers and on-premise infrastructures  ](https://github.com/berops/claudie)	|	![Github Stars](https://img.shields.io/github/stars/berops/claudie)	|
  							
 									
 ## Storage Providers						


### PR DESCRIPTION
Hey @ajeetraina @apurvabhandari 

Tries solving the issue #314 by updating the tool in the Kubernetes Tools for Specific Cloud Section because It allows users to manage Kubernetes clusters that span across multiple cloud providers and on-premise infrastructures.