### PR TITLE
feat: add KubeStellar Console to Cluster Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 | 53 |	k9sight | [ A fast, keyboard-driven TUI for debugging Kubernetes workloads ](https://github.com/doganarif/k9sight) | ![Github Stars](https://img.shields.io/github/stars/doganarif/k9sight) |
 | 54 |	ReleaseRun K8s Deprecation Checker | [ Scan Kubernetes manifests for deprecated and removed APIs across versions 1.16-1.35, with auto-fix YAML output and upgrade timeline ](https://releaserun.com/tools/k8s-deprecation-checker/) | ![Github Stars](https://img.shields.io/github/stars/Releaserun/releaserun-cli) |
 | 55 |	okd-metal-installer | [ Ansible-driven bare-metal OKD provisioning via static ISOs and Bootstrap-in-Place ](https://github.com/tosin2013/okd-metal-installer) | ![Github Stars](https://img.shields.io/github/stars/tosin2013/okd-metal-installer) |
+| 56 |	KubeStellar Console | [ CNCF Sandbox multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and GitOps-native deploy workflows across edge and cloud clusters ](https://github.com/kubestellar/console) | ![Github Stars](https://img.shields.io/github/stars/kubestellar/console) |
 
 
 ## Cluster with Core CLI tools						


### PR DESCRIPTION
## What

Adds **KubeStellar Console** to the Cluster Management table as entry 35a, directly below the existing KubeStellar core project entry.

## Why

KubeStellar Console is a distinct project from `kubestellar/kubestellar` — it is an AI-powered multi-cluster Kubernetes dashboard with:
- Real-time observability across edge and cloud clusters
- CNCF project integrations (Argo, Kyverno, Istio, 20+ projects)
- GitHub OAuth, benchmark tracking, compliance dashboards
- CNCF Sandbox project: https://github.com/kubestellar/console

The existing entry (#35) points to the core KubeStellar project. The Console is the user-facing dashboard that operators actually interact with, and belongs alongside other cluster management UIs in this list.

## Entry added

| 35a | KubeStellar Console | AI-powered multi-cluster Kubernetes dashboard with real-time observability, CNCF project integrations, and edge/cloud cluster management | ⭐ badge |