### PR TITLE
Add k100s

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 | 55 |	okd-metal-installer | [ Ansible-driven bare-metal OKD provisioning via static ISOs and Bootstrap-in-Place ](https://github.com/tosin2013/okd-metal-installer) | ![Github Stars](https://img.shields.io/github/stars/tosin2013/okd-metal-installer) |
 | 56 |	KubeStellar Console | [ CNCF Sandbox multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and GitOps-native deploy workflows across edge and cloud clusters ](https://github.com/kubestellar/console) | ![Github Stars](https://img.shields.io/github/stars/kubestellar/console) |
 | 57 |	Hanoi-CLI | [ Interactive rebalance advisor for Kubernetes that analyzes pod distribution and simulates node failures ](https://github.com/k-krew/hanoi-cli) | ![Github Stars](https://img.shields.io/github/stars/k-krew/hanoi-cli) |
+| 58 |	k100s | [ Free, open-source desktop Kubernetes app for switching contexts and namespaces, viewing pods, streaming logs, and opening pod shells ](https://github.com/AndrewVos/k100s) | ![Github Stars](https://img.shields.io/github/stars/AndrewVos/k100s) |
 
 
 ## Cluster with Core CLI tools						


### PR DESCRIPTION
Adds k100s to the Cluster Management table.

k100s is a free, open-source desktop Kubernetes app for users who want a k9s-like workflow in a GUI. It uses local kubectl/kubeconfig for context and namespace switching, pod lists, streamed logs, describes, and pod shells.

Checks:
- git diff --check