### PR TITLE
feat: add km8 — lightweight Kubernetes TUI for backend engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |	44	|	krelay  	|	[ A better alternative to `kubectl port-forward` that can forward TCP or UDP traffic to IP/Host which is accessible inside the cluster ](https://github.com/knight42/krelay)	|	![Github Stars](https://img.shields.io/github/stars/knight42/krelay)	|
 |	45	|	kubectl-browse-pvc  	|	[ Kubectl plugin for browsing PVCs on the command line ](https://github.com/clbx/kubectl-browse-pvc)	|	![Github Stars](https://img.shields.io/github/stars/clbx/kubectl-browse-pvc)	|
 |	46	|	gwctl  	|	[ Command-line tool for managing and understanding Gateway API resources in your Kubernetes cluster ](https://github.com/kubernetes-sigs/gwctl)	|	![Github Stars](https://img.shields.io/github/stars/kubernetes-sigs/gwctl)	|
+|	47	|	km8	|	[ A lightweight terminal UI for Kubernetes — vim-style navigation, CRD support, drill-down, log streaming, and kubectl edit. Built for backend engineers who want a fast, zero-config alternative to opening a browser ](https://github.com/vulcanshen/km8)	|	![Github Stars](https://img.shields.io/github/stars/vulcanshen/km8)	|
 
 
 


### PR DESCRIPTION
## Tool Description

**km8 (KubeMate)** is a lightweight terminal UI for Kubernetes built with Go and Bubble Tea.

It targets backend engineers who occasionally need to check pods, stream logs, exec into containers, or edit resources — without opening a browser or memorizing long kubectl commands.

## Key Features

- 17 built-in resource types + automatic CRD discovery
- Vim-style navigation (j/k, gg/G, u/d page scroll)
- Drill-down: Deployment → Pod → Container
- Pod log streaming and container shell exec (s)
- kubectl edit integration with custom editor support
- Real-time watch updates
- Zero config required — works out of the box with kubeconfig

## Links

- GitHub: https://github.com/vulcanshen/km8
- Latest release: v1.0.2
- License: GPL-3.0