### PR TITLE
Add piqc and Paralleliq — GPU waste detection and cost optimization for AI workloads on Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |	1	|	Nos  	|	[	nos is an open-source platform to efficiently run AI workloads on Kubernetes, increasing GPU utilization and reducing infrastructure and operational costs](https://github.com/nebuly-ai/nos)	|	![Github Stars](https://img.shields.io/github/stars/nebuly-ai/nos)	|
 |	2	|	Kubeflow  	|	[	Machine Learning Toolkit for Kubernetes](https://github.com/kubeflow/kubeflow)	|	![Github Stars](https://img.shields.io/github/stars/kubeflow/kubeflow)	|
 |	3	|	Volcano  	|	[	A Kubernetes Native Batch System](https://github.com/volcano-sh/volcano)	|	![Github Stars](https://img.shields.io/github/stars/volcano-sh/volcano)	|
+|	4	|	piqc  	|	[	Open-source GPU waste scanner for Kubernetes inference clusters — detects tier misplacement, idle capacity, OOM risk, and CPU:GPU imbalance](https://github.com/paralleliq/piqc)	|	![Github Stars](https://img.shields.io/github/stars/paralleliq/piqc)	|
 									
 									
 ## Compute Edge Tools						
@@ -667,6 +668,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 | 7 | StormForge | [ Autonomous Rightsizing for Kubernetes Workloads ](https://stormforge.io) | - |
 | 8 | Burn | [CLI tool for Kubernetes cost analysis with per-namespace breakdown, real cloud pricing, and AI-powered recommendations](https://github.com/tanrikuluozlem/burn) | ![Github Stars](https://img.shields.io/github/stars/tanrikuluozlem/burn)|
 | 9 | Attune | [ Kubernetes operator for safe, in-place pod resource right-sizing using Prometheus metrics](https://github.com/attune-io/attune) | ![Github Stars](https://img.shields.io/github/stars/attune-io/attune) |
+| 10 | Paralleliq | [Model-aware GPU control plane for AI infrastructure — detects GPU waste, quantifies cost impact, and delivers actionable recommendations with approval workflows](https://www.paralleliq.ai) | - |
 
 	
 ## Function as a Service FaaS			


### PR DESCRIPTION
This PR adds two tools for teams running AI/ML inference workloads on Kubernetes:

### Machine Learning/Deep Learning — piqc

**[piqc](https://github.com/paralleliq/piqc)** is an open-source, read-only GPU waste scanner for Kubernetes inference clusters. It deploys as a Kubernetes Job (no write permissions required), introspects running vLLM workloads, and reports four waste patterns:

- **Tier misplacement** — model running on a GPU with more memory or compute than needed
- **Dark capacity** — GPU allocated but serving no live traffic
- **OOM risk** — model approaching GPU memory ceiling
- **CPU:GPU imbalance** — CPU saturation throttling GPU throughput in agentic workloads

Apache 2.0.

### Cost Optimisation — Paralleliq

**[Paralleliq](https://www.paralleliq.ai)** is a model-aware GPU control plane for AI infrastructure. Unlike generic Kubernetes cost tools that see only resource utilization, Paralleliq understands which model is running on which GPU, what tier it belongs on, and what the cost delta is. It delivers actionable recommendations with human-in-the-loop approval workflows and a full audit trail — complementing tools like Kubecost and OpenCost with AI-specific cost intelligence.