### PR TITLE
Add Attune - in-place pod resource right-sizing operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 | 55 |	okd-metal-installer | [ Ansible-driven bare-metal OKD provisioning via static ISOs and Bootstrap-in-Place ](https://github.com/tosin2013/okd-metal-installer) | ![Github Stars](https://img.shields.io/github/stars/tosin2013/okd-metal-installer) |
 | 56 |	KubeStellar Console | [ CNCF Sandbox multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and GitOps-native deploy workflows across edge and cloud clusters ](https://github.com/kubestellar/console) | ![Github Stars](https://img.shields.io/github/stars/kubestellar/console) |
 | 57 |	Hanoi-CLI | [ Interactive rebalance advisor for Kubernetes that analyzes pod distribution and simulates node failures ](https://github.com/k-krew/hanoi-cli) | ![Github Stars](https://img.shields.io/github/stars/k-krew/hanoi-cli) |
+| 58 |	Attune | [ Kubernetes operator for safe, in-place pod resource right-sizing using real Prometheus metrics. Modern VPA replacement with no pod restarts. ](https://github.com/attune-io/attune) | ![Github Stars](https://img.shields.io/github/stars/attune-io/attune) |
 
 
 ## Cluster with Core CLI tools						


### PR DESCRIPTION
## Attune

[Attune](https://github.com/attune-io/attune) is a Kubernetes operator for safe, in-place pod resource right-sizing using real Prometheus metrics. It serves as a modern VPA replacement that adjusts container CPU and memory requests/limits without pod restarts, leveraging the Kubernetes In-Place Pod Resize feature (1.32+).

**Why it belongs in Cluster Management:** Attune is an operator that continuously right-sizes pod resources based on observed usage, similar in spirit to Goldilocks and Kondense already listed in this section. It fills a gap for teams that want automated resource tuning without the disruption of pod restarts.

- License: Apache 2.0
- Repository: https://github.com/attune-io/attune