### PR TITLE
Add Klustr (native Kubernetes desktop client) to Development Tools/Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |  76  |   helm-controller  |   [ A simple way to manage helm charts with Custom Resource Definitions in k8s ](https://github.com/k3s-io/helm-controller)   |   ![Github Stars](https://img.shields.io/github/stars/k3s-io/helm-controller)  |
 |  77  |   Grafana-Tanka  |   [ Flexible, reusable and concise configuration for Kubernetes ](https://github.com/grafana/tanka)   |   ![Github Stars](https://img.shields.io/github/stars/grafana/tanka)  |
 |  78  |   kubesearch.dev  |   [ Kubesearch is a searchable index of popular Helm chart releases in categories such as observability, networking, storage, and automation ](https://kubesearch.dev/)   |   ![Github Stars](https://img.shields.io/github/stars/whazor/k8s-at-home-search)  |
+|  79  |   Klustr  |   [ A native (non-Electron) cross-platform Kubernetes desktop client driven purely by your kubeconfig — multi-context live views, logs, exec, port-forwarding, RBAC, CRDs, Helm, Argo CD, Flux CD and Gateway API, with nothing installed in the cluster ](https://github.com/SametKUM/klustr)   |   ![Github Stars](https://img.shields.io/github/stars/SametKUM/klustr)  |
 
 
 ## Alternative Tools for Development						


### PR DESCRIPTION
This PR adds **[Klustr](https://github.com/SametKUM/klustr)** to the *Development Tools/Kit* table, alongside the other desktop clients/IDEs already listed there (Lens IDE, Aptakube, K8Studio, Monokle).

**What it is:** a native (non-Electron, Wails/Go + React) cross-platform Kubernetes desktop client.

**Highlights:**
- Pure client — **nothing is installed in the cluster**; drives the standard Kubernetes API via the user's `~/.kube/config`.
- Multi-context aggregated views, live (informer-backed, no polling) resources, logs, exec, port-forwarding, full RBAC browsing.
- First-class **CRD**, **Helm v3**, **Argo CD**, **Flux CD** and **Gateway API** integrations built in — no vendor CLIs shelled out.
- Open source (MIT), actively maintained, cross-platform (macOS, Linux, Windows builds).