### PR TITLE
Add Attune to Cost Optimisation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 | 6 | KBOM | [ KBOM - Kubernetes Bill of Materials ](https://github.com/rad-security/kbom) | ![Github Stars](https://img.shields.io/github/stars/rad-security/kbom) |
 | 7 | StormForge | [ Autonomous Rightsizing for Kubernetes Workloads ](https://stormforge.io) | - |
 | 8 | Burn | [CLI tool for Kubernetes cost analysis with per-namespace breakdown, real cloud pricing, and AI-powered recommendations](https://github.com/tanrikuluozlem/burn) | ![Github Stars](https://img.shields.io/github/stars/tanrikuluozlem/burn)|
+| 9 | Attune | [ Kubernetes operator for safe, in-place pod resource right-sizing using Prometheus metrics](https://github.com/attune-io/attune) | ![Github Stars](https://img.shields.io/github/stars/attune-io/attune) |
 
 	
 ## Function as a Service FaaS			


### PR DESCRIPTION
Adds [Attune](https://github.com/attune-io/attune) to the Cost Optimisation section.

Attune is an open-source (Apache 2.0) Kubernetes operator for safe, in-place pod resource right-sizing using Prometheus metrics. It reduces overprovisioned CPU and memory requests without pod restarts, using the Kubernetes 1.33+ in-place resize API.

Disclosure: I am the maintainer of Attune.