### PR TITLE
Add Omen to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |       14      |	Nighthawk       | [ Nighthawk is Layer5's versatile HTTP load tester. Drills deep with constant & adaptive rates, revealing performance insights ](https://github.com/layer5io/getnighthawk) | ![Github Stars](https://img.shields.io/github/stars/layer5io/getnighthawk) |
 |      15       |	perf-tests      | [ Performance tests and benchmarks ](https://github.com/kubernetes/perf-tests) | ![Github Stars](https://img.shields.io/github/stars/kubernetes/perf-tests) |
 |      16       |	Jupyter Notebook Validator Operator      | [ Kubernetes operator for validating Jupyter notebooks in MLOps (Papermill, golden notebooks) ](https://github.com/tosin2013/jupyter-notebook-validator-operator) | ![Github Stars](https://img.shields.io/github/stars/tosin2013/jupyter-notebook-validator-operator) |
+|      17       |	Omen      | [ Lightweight Kubernetes chaos engineering operator with transparent target selection and optional manual approval ](https://github.com/k-krew/omen) | ![Github Stars](https://img.shields.io/github/stars/k-krew/omen) |
 
 
 


### PR DESCRIPTION
Adds row 17 under Testing Tools for Omen - Lightweight Kubernetes chaos engineering operator.