### PR TITLE
Add Krust Kubernetes dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 | 56 |	KubeStellar Console | [ CNCF Sandbox multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and GitOps-native deploy workflows across edge and cloud clusters ](https://github.com/kubestellar/console) | ![Github Stars](https://img.shields.io/github/stars/kubestellar/console) |
 | 57 |	Hanoi-CLI | [ Interactive rebalance advisor for Kubernetes that analyzes pod distribution and simulates node failures ](https://github.com/k-krew/hanoi-cli) | ![Github Stars](https://img.shields.io/github/stars/k-krew/hanoi-cli) |
 | 58 |	Radar | [ Modern open-source Kubernetes visibility - single binary with multi-cluster topology, image filesystem viewer, Helm and GitOps management (FluxCD/ArgoCD), and a built-in MCP server for AI agents ](https://github.com/skyhook-io/radar) | ![Github Stars](https://img.shields.io/github/stars/skyhook-io/radar) |
+| 59 |	Krust | [ Native macOS Kubernetes dashboard for resources, logs, YAML, Helm, CRDs, topology, port forwarding, metrics, security checks, and AI diagnostics ](https://krust.io/) | - |
 
 
 ## Cluster with Core CLI tools						


### PR DESCRIPTION
Adds Krust to the Cluster Management table.

Krust is a native macOS Kubernetes dashboard for resources, logs, YAML, Helm, CRDs, topology, port forwarding, metrics, security checks, and AI diagnostics. It fits this section alongside Kubernetes dashboard and cluster-management tools such as Octant, Portainer, Kanvas, KubeStellar Console, and Radar.

This follows up on issue #411.