### PR TITLE
Update km8 → kbu (project renamed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |	44	|	krelay  	|	[ A better alternative to `kubectl port-forward` that can forward TCP or UDP traffic to IP/Host which is accessible inside the cluster ](https://github.com/knight42/krelay)	|	![Github Stars](https://img.shields.io/github/stars/knight42/krelay)	|
 |	45	|	kubectl-browse-pvc  	|	[ Kubectl plugin for browsing PVCs on the command line ](https://github.com/clbx/kubectl-browse-pvc)	|	![Github Stars](https://img.shields.io/github/stars/clbx/kubectl-browse-pvc)	|
 |	46	|	gwctl  	|	[ Command-line tool for managing and understanding Gateway API resources in your Kubernetes cluster ](https://github.com/kubernetes-sigs/gwctl)	|	![Github Stars](https://img.shields.io/github/stars/kubernetes-sigs/gwctl)	|
-|	47	|	km8	|	[ A lightweight terminal UI for Kubernetes — vim-style navigation, CRD support, drill-down, log streaming, and kubectl edit. Built for backend engineers who want a fast, zero-config alternative to opening a browser ](https://github.com/vulcanshen/km8)	|	![Github Stars](https://img.shields.io/github/stars/vulcanshen/km8)	|
+|	47	|	kbu	|	[ A single-pane Kubernetes TUI driven by Tab / Space / Enter / Esc — Relatives navigation, side-by-side YAML compare, and an embedded persistent shell. Zero setup, zero hotkey memorization. ](https://github.com/vulcanshen/kbu)	|	![Github Stars](https://img.shields.io/github/stars/vulcanshen/kbu)	|
 
 
 


### PR DESCRIPTION
The project previously listed as **km8** (row 47) has been renamed to **kbu** as of its v2.0.0 release. This PR updates the existing entry:

- Name `km8` → `kbu`
- Repository + stars URLs → `https://github.com/vulcanshen/kbu` (the old `km8` URL still redirects)
- Refreshed the description to reflect the current tool — a single-pane Kubernetes TUI driven by `Tab` / `Space` / `Enter` / `Esc`, with Relatives navigation, side-by-side YAML compare, and an embedded persistent shell

No new row is added; this only updates the entry you already merged. Thanks for maintaining Kubetools!
