### PR TITLE
Add kubectl-outagedeck to Alert and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |	24	|	kcmsu	|	[  K8s ConfigMaps and Secrets Usage ](https://github.com/cristian98149/kcmsu)	|	![Github Stars](https://img.shields.io/github/stars/cristian98149/kcmsu)	|
 |	25	|	WatchAlert	|	[  Lightweight cloud-native multi-data source monitoring and alerting engine ](https://github.com/opsre/WatchAlert)	|	![Github Stars](https://img.shields.io/github/stars/opsre/WatchAlert)	|
 |	26	|	Kubexer Kubernetes IDE	|	[  Desktop Kubernetes IDE with a built-in monitoring and alerting engine — define alert rules on live cluster events and workload health, with namespace-wide metrics and resource comparison ](https://kubexer.com)	|	-	|
+|	27	|	kubectl-outagedeck	|	[ Check official cloud and SaaS provider status for dependencies discovered from Kubernetes workload annotations ](https://github.com/outagedeck/kubectl-outagedeck)	|	![Github Stars](https://img.shields.io/github/stars/outagedeck/kubectl-outagedeck)	|
 
 
 ## Logging and Tracing						


### PR DESCRIPTION
Disclosure: this is an OutageDeck-maintained project.

Adds kubectl-outagedeck as row 27 in Alert and Monitoring. It is a read-only kubectl plugin for checking whether cloud and SaaS dependencies behind annotated Kubernetes workloads are reporting incidents in their official status feeds.

Why it fits this catalog:

- public MIT-licensed source and a versioned six-platform release
- provider checks work with explicit slugs or workload annotations
- namespace, all-namespace, selector, JSON, timeout, and incident-threshold support
- all six release targets pass Krew’s official structural and installation validator
- project CI passes race tests, vet, native build, and six cross-compiles

Repository: https://github.com/outagedeck/kubectl-outagedeck
Release: https://github.com/outagedeck/kubectl-outagedeck/releases/tag/v0.1.0
Krew submission: https://github.com/kubernetes-sigs/krew-index/pull/6153